### PR TITLE
Flask-Pgdb connection fix

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ app = Flask(__name__)
 DB_CONFIG = {
     "dbname": "movies-db",
     "user": "postgres",
+    "password": "your_password_goes_here_if_any",
     "host": "localhost",
     "port": 5432
 }


### PR DESCRIPTION
Had some issues when running the local instance of flask with the pg db connection. Turns out while installation they require a password for the db server and while making the connection to the flask. 

![db-connection-failed image](https://github.com/user-attachments/assets/673b6c9c-0648-4a33-886c-068241c58ade)

Better store your password as `environment variable` and export it to your code, to minimize security issues. Can be done quite easily, will raise an issue for this.